### PR TITLE
Fix version file URL property

### DIFF
--- a/GameData/WildBlueIndustries/KerbalKomets/KerbalKomets.version
+++ b/GameData/WildBlueIndustries/KerbalKomets/KerbalKomets.version
@@ -1,6 +1,6 @@
 {
     "NAME":"Kerbal Komets",
-    "URL":"https://raw.githubusercontent.com/Angel-125/MOLE/master/GameData/WildBlueIndustries/KerbalKomets/KerbalKomets.version",
+    "URL":"https://github.com/Angel-125/KerbalKomets/raw/master/GameData/WildBlueIndustries/KerbalKomets/KerbalKomets.version",
     "DOWNLOAD":"https://github.com/Angel-125/KerbalKomets/releases",
     "GITHUB":
     {


### PR DESCRIPTION
The current URL is a 404 (looks like the repo used to be called MOLE).
Now it's fixed.

Tagging @Angel-125 because not everyone has GitHub notifications enabled for pull requests.